### PR TITLE
Replace PROJECT with Yochu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to contribute
 
-PROJECT is Apache 2.0 licensed and accepts contributions via GitHub pull requests. This document outlines some of the conventions on commit message formatting, contact points for developers and other resources to make getting your contribution into PROJECT easier.
+Yochu is Apache 2.0 licensed and accepts contributions via GitHub pull requests. This document outlines some of the conventions on commit message formatting, contact points for developers and other resources to make getting your contribution into Yochu easier.
 
 # Email and chat
 
@@ -14,7 +14,7 @@ PROJECT is Apache 2.0 licensed and accepts contributions via GitHub pull request
 
 ## Reporting Bugs and Creating Issues
 
-Reporting bugs is one of the best ways to contribute. If you find bugs or documentation mistakes in the PROJECT project, please let us know by [opening an issue](https://github.com/giantswarm/PROJECT/issues/new). We treat bugs and mistakes very seriously and believe no issue is too small. Before creating a bug report, please check there that one does not already exist.
+Reporting bugs is one of the best ways to contribute. If you find bugs or documentation mistakes in the Yochu project, please let us know by [opening an issue](https://github.com/giantswarm/yochu/issues/new). We treat bugs and mistakes very seriously and believe no issue is too small. Before creating a bug report, please check there that one does not already exist.
 
 To make your bug report accurate and easy to understand, please try to create bug reports that are:
 
@@ -22,7 +22,7 @@ To make your bug report accurate and easy to understand, please try to create bu
 
 - Reproducible. Include the steps to reproduce the problem. We understand some issues might be hard to reproduce, please includes the steps that might lead to the problem. If applicable, you can also attach affected data dir(s) and a stack trace to the bug report.
 
-- Isolated. Please try to isolate and reproduce the bug with minimum dependencies. It would significantly slow down the speed to fix a bug if too many dependencies are involved in a bug report. Debugging external systems that rely on PROJECT is out of scope, but we are happy to point you in the right direction or help you interact with PROJECT in the correct manner.
+- Isolated. Please try to isolate and reproduce the bug with minimum dependencies. It would significantly slow down the speed to fix a bug if too many dependencies are involved in a bug report. Debugging external systems that rely on Yochu is out of scope, but we are happy to point you in the right direction or help you interact with Yochu in the correct manner.
 
 - Unique. Do not duplicate existing bug reports.
 
@@ -40,7 +40,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Make commits of logical units.
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.
-- Submit a pull request to giantswarm/PROJECT.
+- Submit a pull request to giantswarm/yochu.
 - Adding unit tests will greatly improve the chance for getting a quick review and your PR accepted.
 - Your PR must receive a LGTM from one maintainer found in the MAINTAINERS file.
 - Before merging your PR be sure to squash all commits into one.


### PR DESCRIPTION
I looked into #6, but couldn't find any differences to https://github.com/giantswarm/example-opensource-repo/blob/master/CONTRIBUTING.md - but I noticed we forgot to replace the projectname. So here we go.

ping @puja108 @JosephSalisbury 