### PR TITLE
make sure changes in templates rebuild the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ deps: .gobuild .gobuild/bin/go-bindata
 	GOPATH=$(GOPATH) builder go get github.com/coreos/go-systemd/dbus
 
 # build
-$(PROJECT): $(SOURCE) VERSION
+$(PROJECT): $(SOURCE) VERSION $(TEMPLATES)
 		docker run \
 	    --rm \
 	    -v $(shell pwd):/usr/code \


### PR DESCRIPTION
`make` didn't compile a new binary after changes in the template. 