### PR TITLE
if overlay is omitted leave out dependency on mount unit

### DIFF
--- a/cli/setup_cmd.go
+++ b/cli/setup_cmd.go
@@ -121,7 +121,8 @@ func setupRun(cmd *cobra.Command, args []string) {
 	}
 
 	// overlay mount service
-	if execute(globalFlags.steps, "overlay") {
+	useOverlay := execute(globalFlags.steps, "overlay")
+	if useOverlay {
 		if err := overlay.Teardown(fsClient, systemdClient, distributionPath, overlayWorkdir, overlayMountPoint); err != nil {
 			ExitStderr(mask(err))
 		}
@@ -163,7 +164,7 @@ func setupRun(cmd *cobra.Command, args []string) {
 
 		// !useIPTables is used, because when the iptables step is enabled, we want
 		// --iptables=false for the docker daemon.
-		if err := docker.Setup(fsClient, systemdClient, fetchClient, overlayMountPoint, dockerVersion, privateRegistry, !useIPTables, startDaemons); err != nil {
+		if err := docker.Setup(fsClient, systemdClient, fetchClient, overlayMountPoint, dockerVersion, privateRegistry, !useIPTables, startDaemons, useOverlay); err != nil {
 			ExitStderr(mask(err))
 		}
 	}
@@ -174,7 +175,7 @@ func setupRun(cmd *cobra.Command, args []string) {
 			ExitStderr(mask(err))
 		}
 
-		if err := fleet.Setup(fsClient, systemdClient, fetchClient, overlayMountPoint, fleetVersion, startDaemons); err != nil {
+		if err := fleet.Setup(fsClient, systemdClient, fetchClient, overlayMountPoint, fleetVersion, startDaemons, useOverlay); err != nil {
 			ExitStderr(mask(err))
 		}
 	}
@@ -185,7 +186,7 @@ func setupRun(cmd *cobra.Command, args []string) {
 			ExitStderr(mask(err))
 		}
 
-		if err := etcd.Setup(fsClient, systemdClient, fetchClient, overlayMountPoint, etcdVersion, startDaemons); err != nil {
+		if err := etcd.Setup(fsClient, systemdClient, fetchClient, overlayMountPoint, etcdVersion, startDaemons, useOverlay); err != nil {
 			ExitStderr(mask(err))
 		}
 	}

--- a/templates/docker.service.tmpl
+++ b/templates/docker.service.tmpl
@@ -7,8 +7,10 @@ After=docker.socket
 Requires=docker-tcp.socket
 After=docker-tcp.socket
 
+{{if .UseOverlay}}
 Requires=usr-bin.mount
 After=usr-bin.mount
+{{end}}
 
 [Service]
 {{if .UseTypeNotify}}Type=Notify{{end}}

--- a/templates/etcd2.service.tmpl
+++ b/templates/etcd2.service.tmpl
@@ -2,7 +2,10 @@
 Description=etcd2
 Conflicts=etcd.service
 
+{{if .UseOverlay}}
+Requires=usr-bin.mount
 After=usr-bin.mount
+{{end}}
 
 [Service]
 User=etcd

--- a/templates/fleet.service.tmpl
+++ b/templates/fleet.service.tmpl
@@ -7,8 +7,10 @@ After=etcd2.service
 Wants=fleet.socket
 After=fleet.socket
 
+{{if .UseOverlay}}
 Requires=usr-bin.mount
 After=usr-bin.mount
+{{end}}
 
 [Service]
 Environment="FLEET_ETCD_REQUEST_TIMEOUT=5" "FLEET_VERBOSITY=0"

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -10,6 +10,7 @@ type dockerOptions struct {
 	PrivateRegistry []string
 	StorageEngine   string
 	UseIPTables     bool
+	UseOverlay      bool
 	UseTypeNotify   bool
 	DockerExecArgs  []string
 }
@@ -47,6 +48,7 @@ func TestDockerServiceRender(t *testing.T) {
 		PrivateRegistry: []string{"private.registry.com"},
 		StorageEngine:   "btrfs",
 		UseIPTables:     true,
+		UseOverlay:      true,
 		UseTypeNotify:   true,
 		DockerExecArgs:  []string{dockerDaemonV1_10Arg, dockerIccEnabledArg},
 	}


### PR DESCRIPTION
In my local setup with conair containers I don't use the overlay step. docker, etcd and fleet currently fail because of a hardcoded dependency on the mount unit in their templates.

so i passed through if the overlay is used to the templates and left out `Requires,After` if overlay isn't used.