### PR TITLE
Add support for provisioning docker 1.11.0 and higher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ deps: .gobuild .gobuild/bin/go-bindata
 	GOPATH=$(GOPATH) builder go get github.com/juju/errgo
 	GOPATH=$(GOPATH) builder go get github.com/spf13/cobra
 	GOPATH=$(GOPATH) builder go get github.com/coreos/go-systemd/dbus
+	GOPATH=$(GOPATH) builder go get github.com/coreos/go-semver
 
 # build
 $(PROJECT): $(SOURCE) VERSION $(TEMPLATES)


### PR DESCRIPTION
Fixes https://github.com/giantswarm/yochu/issues/23

In docker 1.11.0, the docker binary was split into multiple binaries.
This PR checks if the docker version we want is 1.11.0 or higher, and downloads all the necessary binaries from S3 (https://downloads.giantswarm.io/docker/1.11.0/)

Tested with provisioning both docker 1.10.3, and 1.11.0.